### PR TITLE
Fix broken floors in special stages

### DIFF
--- a/SonicCDDecomp/Userdata.cpp
+++ b/SonicCDDecomp/Userdata.cpp
@@ -339,6 +339,10 @@ void InitUserdata()
 #endif
     }
 #endif
+
+#if RETRO_PLATFORM == RETRO_3DS
+    Engine.useHQModes = false; //fixes broken special stage floors
+#endif
 }
 
 void writeSettings() {


### PR DESCRIPTION
3D floors are broken when 'UseHQModes' is true in the settings file. Force it off on 3DS.